### PR TITLE
Remove extra semicolon.

### DIFF
--- a/ouster_client/include/ouster/lidar_scan.h
+++ b/ouster_client/include/ouster/lidar_scan.h
@@ -143,7 +143,7 @@ class LidarScan {
     template <typename Iterator>
     LidarScan(size_t w, size_t h, Iterator begin, Iterator end,
               size_t columns_per_packet = DEFAULT_COLUMNS_PER_PACKET)
-        : LidarScan(w, h, {begin, end}, columns_per_packet){};
+        : LidarScan(w, h, {begin, end}, columns_per_packet){}
 
     /**
      * Initialize a lidar scan from another lidar scan.


### PR DESCRIPTION
## Related Issues & PRs

I noticed the following build error on my machine:
```
In file included from /opt/src/lidar-mapping/src/include/lidar_mapping/utilities.hh:21,
                 from /opt/src/lidar-mapping/src/utilities.cc:14:
/opt/src/ouster_example/ouster_client/include/ouster/lidar_scan.h:146:62: error: extra ‘;’ [-Werror=pedantic]
  146 |         : LidarScan(w, h, {begin, end}, columns_per_packet){};
      |                                                              ^
      |                                                              -
```

## Summary of Changes

Removed the extra semicolon.

## Validation

Built successfully.
